### PR TITLE
Adding license info to the package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,6 +6,7 @@
     "Gary Court": "gary.court@gmail.com",
     "Derek Perez": "derek@derekperez.com"
   },
+  "license": "MIT",
   "main": "murmurhash",
   "repository": {
     "type": "git",


### PR DESCRIPTION
I'm working on the open source project [VersionEye](https://www.versioneye.com). By adding the license info to the package.json it becomes available through the public NPMRegistry API and that way other tools like VersionEye can fetch it easier.