### PR TITLE
Use TextEncoder instead of Buffer

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,8 @@ Install it in your browser:
 <script type="text/javascript" src="murmurhash.js"></script>
 ```
 
+To support older browsers you need to use TextEncoder [polyfill](https://developer.mozilla.org/en-US/docs/Web/API/TextEncoder#Polyfill)
+
 or in node.js
 
 ```

--- a/murmurhash.d.ts
+++ b/murmurhash.d.ts
@@ -1,0 +1,33 @@
+export = murmurhash;
+
+/**
+ * JS Implementation of MurmurHash3 (r136) (as of May 20, 2011)
+ *
+ * @param key - ASCII only
+ * @param seed - (optional) positive integer
+ * @returns 32-bit positive integer hash
+ */
+declare function murmurhash(
+  key: string | Uint8Array,
+  seed?: number
+): number;
+
+declare namespace murmurhash {
+  /**
+   * JS Implementation of MurmurHash3 (r136) (as of May 20, 2011)
+   *
+   * @param key - ASCII only
+   * @param seed - (optional) positive integer
+   * @returns 32-bit positive integer hash
+   */
+  function v3(key: string | Uint8Array, seed?: number): number;
+
+  /**
+   * JS Implementation of MurmurHash2
+   *
+   * @param str - ASCII only
+   * @param seed - (optional) positive integer
+   * @returns 32-bit positive integer hash
+   */
+  function v2(str: string | Uint8Array, seed?: number): number;
+}

--- a/murmurhash.js
+++ b/murmurhash.js
@@ -1,7 +1,7 @@
 (function(){
   var _global = this;
 
-  const createBuffer = (val)=> new TextEncoder().encode(val)
+  const createBuffer = (val) => new TextEncoder().encode(val)
 
   /**
    * JS Implementation of MurmurHash2
@@ -11,7 +11,7 @@
    * @author <a href="mailto:aappleby@gmail.com">Austin Appleby</a>
    * @see http://sites.google.com/site/murmurhash/
    *
-   * @param {Buffer | Uint8Array | string} str ASCII only
+   * @param {Uint8Array | string} str ASCII only
    * @param {number} seed Positive integer only
    * @return {number} 32-bit positive integer hash
    */
@@ -62,7 +62,7 @@
    * @author <a href="mailto:aappleby@gmail.com">Austin Appleby</a>
    * @see http://sites.google.com/site/murmurhash/
    *
-   * @param {Buffer | Uint8Array | string} key ASCII only
+   * @param {Uint8Array | string} key ASCII only
    * @param {number} seed Positive integer only
    * @return {number} 32-bit positive integer hash
    */

--- a/murmurhash.js
+++ b/murmurhash.js
@@ -1,11 +1,7 @@
 (function(){
   var _global = this;
 
-  const createBuffer =
-    Buffer.from && Buffer.alloc && Buffer.allocUnsafe && Buffer.allocUnsafeSlow
-      ? Buffer.from
-      : // support for Node < 5.10
-        val => new Buffer(val);
+  const createBuffer = (val)=> new TextEncoder().encode(val)
 
   /**
    * JS Implementation of MurmurHash2
@@ -15,12 +11,12 @@
    * @author <a href="mailto:aappleby@gmail.com">Austin Appleby</a>
    * @see http://sites.google.com/site/murmurhash/
    *
-   * @param {Buffer} str ASCII only
+   * @param {Buffer | Uint8Array | string} str ASCII only
    * @param {number} seed Positive integer only
    * @return {number} 32-bit positive integer hash
    */
   function MurmurHashV2(str, seed) {
-    if (!Buffer.isBuffer(str)) str = createBuffer(str);
+    if (typeof str === 'string') str = createBuffer(str);
     var
       l = str.length,
       h = seed ^ l,
@@ -66,12 +62,12 @@
    * @author <a href="mailto:aappleby@gmail.com">Austin Appleby</a>
    * @see http://sites.google.com/site/murmurhash/
    *
-   * @param {Buffer} key ASCII only
+   * @param {Buffer | Uint8Array | string} key ASCII only
    * @param {number} seed Positive integer only
    * @return {number} 32-bit positive integer hash
    */
   function MurmurHashV3(key, seed) {
-    if (!Buffer.isBuffer(key)) key = createBuffer(key);
+    if (typeof key === 'string') key = createBuffer(key);
 
     var remainder, bytes, h1, h1b, c1, c1b, c2, c2b, k1, i;
 

--- a/test.js
+++ b/test.js
@@ -1,0 +1,13 @@
+const { v3 } = require("./murmurhash");
+
+const fromStr = v3("abc");
+const fromBuffer = v3(Buffer.from("abc"));
+const fromUnit8Array = v3(new Uint8Array([97, 98, 99]));
+
+if (
+  fromStr !== fromBuffer ||
+  fromBuffer !== fromUnit8Array ||
+  fromStr !== 3017643002
+) {
+  throw new Error(`Wrong output`);
+}


### PR DESCRIPTION
fixes #7 

So I'm not 100% sure about this since there are no tests. I added a small test just to make sure that it still works with all types of input. I didn't connect it to the publish flow but I will if needed.

* keep an eye on the replacement of the `Buffer.isBuffer` check.

After this change it will no more be **node**-murmurhash because it's just works on every browser (ie still needs a polyfill). so maybe it needed to be reflected in the docs.

I know it's not related but since this project so small I also I wanted to convert it to typescript but I'm not sure if it's welcome. maybe I can just add the typescript definitions here? (it will remove the `@types/murmurhash` requirement in typescript projects)
 